### PR TITLE
Remove java.desktop module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,8 @@ jobs:
           java-version: '11'
 
       - name: Run jlink
-        run: jlink --output ${{ matrix.os }}/ --add-modules java.base,java.logging,java.naming,java.xml,java.sql,java.transaction.xa,java.security.sasl,java.desktop,java.management
+        run: jlink --output ${{ matrix.os }}/ --add-modules java.base,java.logging,java.naming,java.xml,java.sql,java.transaction.xa,java.security.sasl,java.management
+
       - name: Zip artifact on linux/macos
         if: ${{ matrix.os != 'windows-latest' }}
         run: zip -r ${{ matrix.os }}-jre.zip ${{ matrix.os }}


### PR DESCRIPTION
Now that lrsql uses Hikari, it has no need for the java.desktop module, so we can merge this branch in.