### PR TITLE
Dependencies update

### DIFF
--- a/.github/workflows/runtimer.yml
+++ b/.github/workflows/runtimer.yml
@@ -47,7 +47,7 @@ jobs:
         run: 7z a -tzip ${{ matrix.os }}-jre.zip ${{ matrix.os }}\
 
       - name: Archive for transfer to draft_release job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-jre
           path: ${{ matrix.os }}-jre.zip

--- a/.github/workflows/runtimer.yml
+++ b/.github/workflows/runtimer.yml
@@ -28,11 +28,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-
       - name: Prepare java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version  }}


### PR DESCRIPTION
- Update actions/setup-java to v4
- Update actions/upload-artifact to v4

NOTE: This is a breaking update, as subsequent calls to actions/download-artifact (to download the JREs) will need to be updated to v4.